### PR TITLE
Fixing copyright display

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -8,6 +8,9 @@ disableKinds = ["page", "section", "taxonomy", "taxonomyTerm", "RSS", "sitemap",
 # Enter your tracking code to enable Google Analytics
 googleAnalytics = ""
 
+# Copyright
+copyright = "&copy;2017 Your Name"
+
 [params]
 
   # Metadata for search engines and social sharing
@@ -18,9 +21,6 @@ googleAnalytics = ""
 
   # Favicon
   favicon = "favicon.ico"
-
-  # Copyright
-  copyright = "&copy;2017 Your Name"
 
   # Section - Content
   [params.content]

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <div class="split-credit">
-  <p>{{ .Site.Copyright | safeHTML }} - <a href="https://onepagelove.com/split">Split Template</a> by <a href="https://onepagelove.com">One Page Love</a></p>
+  <p>{{ .Site.Params.Copyright | safeHTML }} - <a href="https://onepagelove.com/split">Split Template</a> by <a href="https://onepagelove.com">One Page Love</a></p>
 
   {{ "<!--" | safeHTML }}
   {{ "To edit this credit you can remove the CC3.0 license for only $5 here: https://onepagelove.com/split" | safeHTML }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <div class="split-credit">
-  <p>{{ .Site.Params.Copyright | safeHTML }} - <a href="https://onepagelove.com/split">Split Template</a> by <a href="https://onepagelove.com">One Page Love</a></p>
+  <p>{{ .Site.Copyright | safeHTML }} - <a href="https://onepagelove.com/split">Split Template</a> by <a href="https://onepagelove.com">One Page Love</a></p>
 
   {{ "<!--" | safeHTML }}
   {{ "To edit this credit you can remove the CC3.0 license for only $5 here: https://onepagelove.com/split" | safeHTML }}


### PR DESCRIPTION
Copyright from default configuration of `exampleSite/config.toml` and `README.md` was not being used.